### PR TITLE
Make threadpool a non-singleton class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ helix-core-api/
 # Depot conversion results
 clones/
 *.log
+
+# LSP
+.cache/
+compile_commands.json
+.ccls-cache/

--- a/p4-fusion/commands/change_list.h
+++ b/p4-fusion/commands/change_list.h
@@ -13,6 +13,7 @@
 
 #include "common.h"
 #include "file_data.h"
+#include "thread_pool.h"
 
 struct ChangeList
 {
@@ -28,8 +29,8 @@ struct ChangeList
 	std::shared_ptr<std::mutex> commitMutex;
 	std::shared_ptr<std::condition_variable> commitCV;
 
-	void PrepareDownload();
-	void StartDownload(const std::string& depotPath, const int& printBatch, const bool includeBinaries);
+	void PrepareDownload(ThreadPool& thread_pool = SystemThreadPool::instance());
+	void StartDownload(const std::string& depotPath, const int& printBatch, const bool includeBinaries, ThreadPool& thread_pool = SystemThreadPool::instance());
 	void WaitForDownload();
 	void Clear();
 };

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -206,7 +206,7 @@ int Main(int argc, char** argv)
 	}
 
 	PRINT("Creating " << networkThreads << " network threads");
-	ThreadPool::GetSingleton()->Initialize(networkThreads);
+	SystemThreadPool::instance(networkThreads);
 
 	int startupDownloadsCount = 0;
 	long long lastDownloadCL = -1;
@@ -246,13 +246,13 @@ int Main(int argc, char** argv)
 		// See if the threadpool encountered any exceptions
 		try
 		{
-			ThreadPool::GetSingleton()->RaiseCaughtExceptions();
+		  SystemThreadPool::instance().RaiseCaughtExceptions();
 		}
 		catch (const std::exception& e)
 		{
 			// Threadpool encountered an exception, this is unrecoverable
 			ERR("Threadpool encountered an exception: " << e.what());
-			ThreadPool::GetSingleton()->ShutDown();
+			SystemThreadPool::instance().ShutDown();
 			std::exit(1);
 		}
 
@@ -317,7 +317,7 @@ int Main(int argc, char** argv)
 
 	SUCCESS("Completed conversion of " << changes.size() << " CLs in " << programTimer.GetTimeS() / 60.0f << " minutes, taking " << commitTimer.GetTimeS() / 60.0f << " to commit CLs");
 
-	ThreadPool::GetSingleton()->ShutDown();
+	SystemThreadPool::instance().ShutDown();
 
 	if (!P4API::ShutdownLibraries())
 	{
@@ -342,7 +342,7 @@ void SignalHandler(sig_atomic_t s)
 
 	ERR("Signal Received: " << strsignal(s));
 
-	ThreadPool::GetSingleton()->ShutDown();
+	SystemThreadPool::instance().ShutDown();;
 
 	std::exit(1);
 }

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -36,16 +36,23 @@ class ThreadPool
 	std::atomic<long> m_JobsProcessing;
 
 public:
-	static ThreadPool* GetSingleton();
+	ThreadPool(int size);
 
 	~ThreadPool();
 
 	void Initialize(int size);
 	void AddJob(Job function);
-	void Wait();
 	void RaiseCaughtExceptions();
 	void ShutDown();
 
-	void Resize(int size);
 	int GetThreadCount() const { return m_Threads.size(); }
+private:
+	void run(unsigned i);
 };
+
+namespace SystemThreadPool{
+	ThreadPool& instance(int size = std::thread::hardware_concurrency()){
+		static ThreadPool default_thread_pool(size);
+		return default_thread_pool;
+	}
+}


### PR DESCRIPTION
The main idea of singleton pattern is to restrict to only have a single instance of class. However, this is highly misused for accessing purpose. This is the same case here.

There is no valid reasoning why thread pool class should not have any multiple instance. (One can argument "because we don't need 2 threadpool in project", but then we are breaking single responsibility principle by putting this knowledge inside threadpool by making it singleton.)

Also having singleton class means, we are having it as a hidden dependency. Also if a function utilizes singleton that means it can make side effects without the knowledge of caller.

I have used dependency injection technique to make threadpool a explicit dependency to the functions, so that there is no 'surprise' side effect. One can argue that having explicit dependency can be hard to call everytime and thus I have used default argument feature of c++ to not disturb the old API for calling.

The default argument binded is a static threadpool that is created when first time instance is called (producing the same old effect of creation when it was singleton). This is very same to analogy that std::cout is a static instance of std::ostream and std::ostream is not a singleton. We just needed to access a static member of project and for that we don't need to make the class singleton.

This refactor would help me decouple few more things from threadpool, to enhance performance. 