### PR TITLE
[WIP] task stealing mechanism for thread pool better performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ helix-core-api/
 # Depot conversion results
 clones/
 *.log
+
+# LSP
+compile_commands.json
+.cache/
+.ccls-cache/

--- a/p4-fusion/notification_queue.cc
+++ b/p4-fusion/notification_queue.cc
@@ -20,7 +20,7 @@ bool NotificationQueue::Pop(std::function<void(P4API*)>& x)
 	std::unique_lock<std::mutex> lock { *m_Mutex };
 	while (m_Queue.empty() && !m_Done)
 		m_Ready->wait(lock);
-	if (m_Queue.empty())
+	if (m_Done || m_Queue.empty())
 		return false;
 	x = std::move(m_Queue.front());
 	m_Queue.pop_front();
@@ -30,7 +30,7 @@ bool NotificationQueue::Pop(std::function<void(P4API*)>& x)
 bool NotificationQueue::TryPop(std::function<void(P4API*)>& x)
 {
 	std::unique_lock<std::mutex> lock { *m_Mutex, std::try_to_lock };
-	if (!lock || m_Queue.empty())
+	if (!lock || m_Done || m_Queue.empty())
 		return false;
 	x = std::move(m_Queue.front());
 	m_Queue.pop_front();

--- a/p4-fusion/notification_queue.cc
+++ b/p4-fusion/notification_queue.cc
@@ -1,0 +1,32 @@
+#include "notification_queue.h"
+
+void notification_queue::done()
+{
+	{
+		std::unique_lock<std::mutex> lock { mutex_ };
+		done_ = true;
+	}
+	ready_.notify_all();
+}
+
+bool notification_queue::pop(std::function<void(P4API*)>& x)
+{
+	std::unique_lock<std::mutex> lock { mutex_ };
+	while (q_.empty() && !done_)
+		ready_.wait(lock);
+	if (q_.empty())
+		return false;
+	x = q_.front();
+	q_.pop_front();
+	return true;
+}
+
+bool notification_queue::try_pop(std::function<void(P4API*)>& x)
+{
+	std::unique_lock<std::mutex> lock { mutex_, std::try_to_lock };
+	if (!lock || q_.empty())
+		return false;
+	x = q_.front();
+	q_.pop_front();
+	return true;
+}

--- a/p4-fusion/notification_queue.cc
+++ b/p4-fusion/notification_queue.cc
@@ -1,7 +1,8 @@
 #include "notification_queue.h"
 
 NotificationQueue::NotificationQueue()
-    : m_Ready(new std::condition_variable), m_Mutex(new std::mutex)
+    : m_Ready(new std::condition_variable)
+    , m_Mutex(new std::mutex)
 {
 }
 
@@ -21,7 +22,7 @@ bool NotificationQueue::Pop(std::function<void(P4API*)>& x)
 		m_Ready->wait(lock);
 	if (m_Queue.empty())
 		return false;
-	x = m_Queue.front();
+	x = std::move(m_Queue.front());
 	m_Queue.pop_front();
 	return true;
 }
@@ -31,7 +32,7 @@ bool NotificationQueue::TryPop(std::function<void(P4API*)>& x)
 	std::unique_lock<std::mutex> lock { *m_Mutex, std::try_to_lock };
 	if (!lock || m_Queue.empty())
 		return false;
-	x = m_Queue.front();
+	x = std::move(m_Queue.front());
 	m_Queue.pop_front();
 	return true;
 }

--- a/p4-fusion/notification_queue.h
+++ b/p4-fusion/notification_queue.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+
+class P4API;
+
+class notification_queue
+{
+	std::deque<std::function<void(P4API*)>> q_;
+	std::mutex mutex_;
+	bool done_ { false };
+	std::condition_variable ready_;
+
+public:
+	void done();
+
+	bool try_pop(std::function<void(P4API*)>& x);
+
+	bool pop(std::function<void(P4API*)>& x);
+
+	template <typename F>
+	void push(F&& f)
+	{
+		{
+			std::unique_lock<std::mutex> lock { mutex_ };
+			q_.emplace_back(std::forward<F>(f));
+		}
+		ready_.notify_one();
+	}
+
+	template <typename F>
+	bool try_push(F&& f)
+	{
+		{
+			std::unique_lock<std::mutex> lock { mutex_, std::try_to_lock };
+			if (!lock)
+				return false;
+			q_.emplace_back(std::forward<F>(f));
+		}
+		ready_.notify_one();
+		return true;
+	}
+};

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -64,14 +64,13 @@ void ThreadPool::Initialize(unsigned size)
 {
 	m_Count = size;
 	m_Index = 0;
-	m_TaskQueue.clear();
+	m_TaskQueue.resize(m_Count);
 	m_HasShutDownBeenCalled = false;
 
 	m_P4Contexts.resize(size);
 
 	for (unsigned i = 0u; i < size; i++)
 	{
-		m_TaskQueue.push_back(NotificationQueue());
 		m_ThreadExceptions.push_back(nullptr);
 		m_ThreadNames.push_back("Worker #" + std::to_string(i));
 		m_Threads.emplace_back([this, i]()

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -19,16 +19,6 @@ ThreadPool* ThreadPool::GetSingleton()
 	return &singleton;
 }
 
-void ThreadPool::AddJob(Job function)
-{
-	{
-		std::unique_lock<std::mutex> lock(m_JobsMutex);
-		m_Jobs.push_back(function);
-		m_JobsProcessing++;
-	}
-	m_CV.notify_one();
-}
-
 void ThreadPool::Wait()
 {
 	while (true)
@@ -59,12 +49,10 @@ void ThreadPool::ShutDown()
 	}
 	m_HasShutDownBeenCalled = true;
 
+	for (auto& q : m_q)
 	{
-		std::unique_lock<std::mutex> lock(m_JobsMutex);
-		m_ShouldStop = true;
+		q.done();
 	}
-	m_CV.notify_all();
-
 	for (auto& thread : m_Threads)
 	{
 		thread.join();
@@ -83,56 +71,51 @@ void ThreadPool::Resize(int size)
 	Initialize(size);
 }
 
-void ThreadPool::Initialize(int size)
+void ThreadPool::Initialize(unsigned size)
 {
+	m_count = size;
+	m_index = 0;
+	m_q.resize(m_count);
 	m_HasShutDownBeenCalled = false;
-	m_ShouldStop = false;
 	m_JobsProcessing = 0;
 
 	m_P4Contexts.resize(size);
 
-	for (int i = 0; i < size; i++)
+	for (unsigned i = 0u; i < size; i++)
 	{
 		m_ThreadExceptions.push_back(nullptr);
 		m_ThreadNames.push_back("Worker #" + std::to_string(i));
-		m_Threads.push_back(std::thread([this, i]()
+		m_Threads.emplace_back([this, i]()
 		    {
 			    MTR_META_THREAD_NAME(m_ThreadNames.at(i).c_str());
-
-			    P4API* localP4 = &m_P4Contexts[i];
-
-			    while (true)
-			    {
-				    Job job;
-				    {
-					    std::unique_lock<std::mutex> lock(m_JobsMutex);
-
-					    m_CV.wait(lock, [this]()
-					        { return !m_Jobs.empty() || m_ShouldStop; });
-
-					    if (m_ShouldStop)
-					    {
-						    break;
-					    }
-
-					    job = m_Jobs.front();
-					    m_Jobs.pop_front();
-				    }
-
-				    try
-				    {
-					    job(localP4);
-				    }
-				    catch (const std::exception& e)
-				    {
-					    m_ThreadExceptions[i] = std::current_exception();
-				    }
-				    m_JobsProcessing--;
-			    }
-		    }));
+			    run(i); });
 	}
 
 	SUCCESS("Created " << size << " threads in thread pool");
+}
+
+void ThreadPool::run(unsigned i)
+{
+	while (true)
+	{
+		std::function<void(P4API*)> f;
+		for (unsigned n = 0; n != m_count; ++n)
+		{
+			if (!m_q[(i + n) % m_count].try_pop(f))
+				break;
+		}
+		if (!f && !m_q[i].pop(f))
+			break;
+		try
+		{
+			f(&m_P4Contexts[i]);
+		}
+		catch (const std::exception& e)
+		{
+			m_ThreadExceptions[i] = std::current_exception();
+		}
+		m_JobsProcessing--;
+	}
 }
 
 ThreadPool::~ThreadPool()

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -90,7 +90,7 @@ void ThreadPool::run(unsigned i)
 		std::function<void(P4API*)> f;
 		for (unsigned n = 0; n != m_Count; ++n)
 		{
-			if (!m_TaskQueue[(i + n) % m_Count].TryPop(f))
+			if (m_TaskQueue[(i + n) % m_Count].TryPop(f))
 				break;
 		}
 		if (!f && !m_TaskQueue[i].Pop(f))

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -19,17 +19,6 @@ ThreadPool* ThreadPool::GetSingleton()
 	return &singleton;
 }
 
-void ThreadPool::Wait()
-{
-	while (true)
-	{
-		if (m_JobsProcessing == 0)
-		{
-			return;
-		}
-	}
-}
-
 void ThreadPool::RaiseCaughtExceptions()
 {
 	for (auto& exceptionPtr : m_ThreadExceptions)
@@ -77,7 +66,6 @@ void ThreadPool::Initialize(unsigned size)
 	m_Index = 0;
 	m_TaskQueue.clear();
 	m_HasShutDownBeenCalled = false;
-	m_JobsProcessing = 0;
 
 	m_P4Contexts.resize(size);
 
@@ -115,7 +103,6 @@ void ThreadPool::run(unsigned i)
 		{
 			m_ThreadExceptions[i] = std::current_exception();
 		}
-		m_JobsProcessing--;
 	}
 }
 

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -19,8 +19,6 @@ class P4API;
 
 class ThreadPool
 {
-	typedef std::function<void(P4API*)> Job;
-
 	std::vector<std::thread> m_Threads;
 	std::vector<std::exception_ptr> m_ThreadExceptions;
 	std::vector<std::string> m_ThreadNames;

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -31,8 +31,6 @@ class ThreadPool
 
 	bool m_HasShutDownBeenCalled;
 
-	std::atomic<long> m_JobsProcessing;
-
 private:
 	void run(unsigned i);
 
@@ -54,7 +52,6 @@ public:
 		}
 		m_TaskQueue[i % m_Count].Push(std::forward<F>(function));
 	}
-	void Wait();
 	void RaiseCaughtExceptions();
 	void ShutDown();
 

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <atomic>
 #include <condition_variable>
+#include "notification_queue.h"
 
 #include "common.h"
 
@@ -24,24 +25,35 @@ class ThreadPool
 	std::vector<std::exception_ptr> m_ThreadExceptions;
 	std::vector<std::string> m_ThreadNames;
 	std::vector<P4API> m_P4Contexts;
+	unsigned m_count;
+	std::atomic<unsigned> m_index { 0 };
+	std::vector<notification_queue> m_q;
 
-	std::deque<Job> m_Jobs;
-	std::mutex m_JobsMutex;
-
-	std::condition_variable m_CV;
-
-	std::atomic<bool> m_ShouldStop;
 	bool m_HasShutDownBeenCalled;
 
 	std::atomic<long> m_JobsProcessing;
+
+private:
+	void run(unsigned i);
 
 public:
 	static ThreadPool* GetSingleton();
 
 	~ThreadPool();
 
-	void Initialize(int size);
-	void AddJob(Job function);
+	void Initialize(unsigned size);
+
+	template <typename F>
+	void AddJob(F&& function)
+	{
+		auto i = m_index++; // overflow of unsigned is well defined so no problem here
+		for (unsigned n = 0; n != m_count; ++n)
+		{
+			if (m_q[(i + n) % m_count].try_push(std::forward<F>(function)))
+				return;
+		}
+		m_q[i % m_count].push(std::forward<F>(function));
+	}
 	void Wait();
 	void RaiseCaughtExceptions();
 	void ShutDown();

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -25,9 +25,9 @@ class ThreadPool
 	std::vector<std::exception_ptr> m_ThreadExceptions;
 	std::vector<std::string> m_ThreadNames;
 	std::vector<P4API> m_P4Contexts;
-	unsigned m_count;
-	std::atomic<unsigned> m_index { 0 };
-	std::vector<notification_queue> m_q;
+	unsigned m_Count;
+	std::atomic<unsigned> m_Index { 0 };
+	std::vector<NotificationQueue> m_TaskQueue;
 
 	bool m_HasShutDownBeenCalled;
 
@@ -46,13 +46,13 @@ public:
 	template <typename F>
 	void AddJob(F&& function)
 	{
-		auto i = m_index++; // overflow of unsigned is well defined so no problem here
-		for (unsigned n = 0; n != m_count; ++n)
+		auto i = m_Index++; // overflow of unsigned is well defined so no problem here
+		for (unsigned n = 0; n != m_Count; ++n)
 		{
-			if (m_q[(i + n) % m_count].try_push(std::forward<F>(function)))
+			if (m_TaskQueue[(i + n) % m_Count].TryPush(std::forward<F>(function)))
 				return;
 		}
-		m_q[i % m_count].push(std::forward<F>(function));
+		m_TaskQueue[i % m_Count].Push(std::forward<F>(function));
 	}
 	void Wait();
 	void RaiseCaughtExceptions();


### PR DESCRIPTION
## Current implementation of threadpool looks as follows

<img src="https://user-images.githubusercontent.com/26287448/149549940-d5d3a76c-fcaf-48fa-baba-efd1deb42c38.png"  height=200/>

There is a huge problem with this implementation: Contention.

Every-time a thread would try to push or pop a task, it needs to acquire a mutex. If another thread is pushing or popping at same time, we need to block. This blocking leads to context switching kills performance and many other tasks could be done at this time. Too much context switching can degrade performance as it is like to have a single thread.

<img src="https://user-images.githubusercontent.com/26287448/149550431-88a1ca8d-0c9f-46e3-8be2-2aa31eb01371.png" height=200/>

## Enhancement 1

Instead of blocking for a single task_queue, each thread would have their own task_queue. With this, there is no need to block if other thread is popping the result and we are pushing to some other queue. We can push task in simple round robin fashion. This looks as follows:
<img src = "https://user-images.githubusercontent.com/26287448/149551652-519abfc3-6d8a-46f2-a9f6-25b7dfbb5d84.png" height = 200/>

## Problem with enhancement 1
It can be possible that, some long running task are getting accumulated to one task queue and other task queue are just sitting idle. Also, still it is possible that a thread is trying to pop from its task queue and we are pushing to same task queue and that point that thread needs to block and this kills performance.

## Proposed Solution (Enhancement 2)
We can implement task stealing so that no task queue bubble up tasks with remaining task queue sitting idle. The main idea here is when thread needs to pop a task from task_queue, it would "try" to pop. If it is not able to pop(because someone else is popping and mutex is acquired or queue is empty) it moves to next task queue. If in a cycle it was not able to pop, then only it blocks for its queue.
Also while pushing to queue, it "try" to push to every task queue. If it is not able to push because some other thread is holding that mutex, then it tries to push to other task queue. If in a cycle it was not able to push to any queue, then only it blocks for its queue.

This looks as follows:
<img src = "https://user-images.githubusercontent.com/26287448/149553140-dfceb394-2392-4541-8970-c68b5b3c43bd.png" height=200/>

This solution ensures that, a thread is spending least time in blocking. And thus in context switching.

## Implementation challenges
This solution currently doesn't compile. The reasons goes as follows. My previous PR was regarding threadpool should not be a singleton. I have a notification_queue class that is abstraction for task queue. Now, we need ``std::conditional_variable`` as a data member of notification_queue for blocking till queue is empty or we are done.

``std::conditional_variable`` is not copy and move constructible (obviously it should not be). This leads to notification_queue not to be copy and move constructible. It should not be too as its acting as a resource for a thread processing.

Talking about ``Initialize`` method of threadpool, it needs to initialize ``std::vector<notification_queue> m_q``.
There are 2 ways of doing this:
- ``m_q.resize(count_threads)``
- ``m_q.clear()`` and then for count_thread times push/emplace_back notification_queue to m_q

With any of 2 approach, notification_queue needs to be copy/move constructible: resize for obvious reasons, and in second approach push_back and emplace_back needs that.

This happens because, initialization of data structures happen at time of ``static ThreadPool thread_pool``. When we call our ``Initialize`` function, it modifies the data structure not actually initialize it. (Assignment and construction are 2 very different operation inspite of having very similar syntax). This modification needs copy/move construction but initialization of m_q in constructor would have done that in-place that would not need any copy/move of notification_queue.

I would comment on part of code that isn't compilable for the time and then we can discuss what measures we can take.
