### PR TITLE
p4: Fix .git file used by submodules

### DIFF
--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -54,7 +54,8 @@ void ChangeList::StartDownload(const std::string& depotPath, const int& printBat
 			if (p4->IsFileUnderDepotPath(fileData.depotFile, depotPath)
 			    && p4->IsFileUnderClientSpec(fileData.depotFile)
 			    && (includeBinaries || !p4->IsBinary(fileData.type))
-			    && (fileData.depotFile.find("/.git/") == std::string::npos)) // To avoid adding .git files in the Perforce history if any
+			    && (fileData.depotFile.find("/.git/") == std::string::npos) // To avoid adding .git/ files in the Perforce history if any
+			    && (std::string(fileData.depotFile.end() - 5, fileData.depotFile.end()) != "/.git")) // To avoid adding .git submodule file in the Perforce history if any
 			{
 				fileData.shouldCommit = true;
 				printBatchFiles->push_back(fileData.depotFile + "#" + fileData.revision);


### PR DESCRIPTION
This PR aims to ignore .git file.

For further details, please see https://github.com/salesforce/p4-fusion/issues/14.
