### PR TITLE
git: Strip away the depot path from the beginning of the file path

### DIFF
--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -34,8 +34,8 @@ public:
 	git_oid CreateBlob(const std::vector<char>& data);
 
 	void CreateIndex();
-	void AddFileToIndex(const std::string& depotFile, const std::vector<char>& contents, const bool plusx);
-	void RemoveFileFromIndex(const std::string& depotFile);
+	void AddFileToIndex(const std::string& depotPath, const std::string& depotFile, const std::vector<char>& contents, const bool plusx);
+	void RemoveFileFromIndex(const std::string& depotPath, const std::string& depotFile);
 	std::string Commit(
 	    const std::string& depotPath,
 	    const std::string& cl,

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -250,11 +250,11 @@ int Main(int argc, char** argv)
 			{
 				if (p4.IsDeleted(file.action))
 				{
-					git.RemoveFileFromIndex(file.depotFile);
+					git.RemoveFileFromIndex(depotPath, file.depotFile);
 				}
 				else
 				{
-					git.AddFileToIndex(file.depotFile, file.contents, p4.IsExecutable(file.type));
+					git.AddFileToIndex(depotPath, file.depotFile, file.contents, p4.IsExecutable(file.type));
 				}
 
 				// No use for keeping the contents in memory once it has been added

--- a/p4-fusion/utils/std_helpers.cc
+++ b/p4-fusion/utils/std_helpers.cc
@@ -30,3 +30,13 @@ bool STDHelpers::Contains(const std::string& str, const std::string& subStr)
 {
 	return str.find(subStr) != std::string::npos;
 }
+
+void STDHelpers::Erase(std::string& source, const std::string& subStr)
+{
+	if (!Contains(source, subStr))
+	{
+		return;
+	}
+
+	source.erase(source.find(subStr), subStr.size());
+}

--- a/p4-fusion/utils/std_helpers.h
+++ b/p4-fusion/utils/std_helpers.h
@@ -14,4 +14,5 @@ public:
 	static bool EndsWith(const std::string& str, const std::string& checkStr);
 	static bool StartsWith(const std::string& str, const std::string& checkStr);
 	static bool Contains(const std::string& str, const std::string& subStr);
+	static void Erase(std::string& source, const std::string& subStr);
 };

--- a/tests/tests.common.h
+++ b/tests/tests.common.h
@@ -9,17 +9,21 @@
 #define TEST_START() \
 	static int32_t failedTestCaseCount = 0;
 
-#define TEST(value, expected)                       \
-	if (value == expected)                          \
-	{                                               \
-		PRINT(#value << " == " << #expected);       \
-	}                                               \
-	else                                            \
-	{                                               \
-		failedTestCaseCount++;                      \
-		ERR(#value << " == " << value << " but != " \
-		           << #expected << " (expected)");  \
-	}
+#define TEST(value, expected)                            \
+	do                                                   \
+	{                                                    \
+		bool result = (value == expected);               \
+		if (result)                                      \
+		{                                                \
+			PRINT(#value << " == " << #expected);        \
+		}                                                \
+		else                                             \
+		{                                                \
+			failedTestCaseCount++;                       \
+			ERR(#value << " == " << result << " but != " \
+			           << #expected << " (expected)");   \
+		}                                                \
+	} while (false)
 
 #define TEST_END()                                          \
 	if (failedTestCaseCount != 0)                           \

--- a/tests/tests.git.h
+++ b/tests/tests.git.h
@@ -17,7 +17,7 @@ int TestGitAPI()
 
 	TEST(git.InitializeRepository("/tmp/test-repo"), true);
 	git.CreateIndex();
-	git.AddFileToIndex("//a/b/c/foo.txt", { 'x', 'y', 'z' }, false);
+	git.AddFileToIndex("//a/b/c/...", "//a/b/c/foo.txt", { 'x', 'y', 'z' }, false);
 	git.Commit(
 	    "//a/b/c/...",
 	    "12345678",
@@ -32,7 +32,7 @@ int TestGitAPI()
 	TEST(git.IsRepositoryClonedFrom("//x/y/z/..."), false);
 	TEST(git.DetectLatestCL(), "12345678");
 
-	git.RemoveFileFromIndex("//a/b/c/foo.txt");
+	git.RemoveFileFromIndex("//a/b/c/...", "//a/b/c/foo.txt");
 	git.Commit(
 	    "//a/b/c/...",
 	    "12345679",

--- a/tests/tests.utils.h
+++ b/tests/tests.utils.h
@@ -55,6 +55,22 @@ int TestUtils()
 	TEST(STDHelpers::EndsWith("//depot/path/.git", "/.git/"), false);
 	TEST(STDHelpers::EndsWith("//depot/path/.git", ".git"), true);
 
+	{
+		std::string depotPath = "//depot/path/";
+		std::string filePath = "//depot/path/foo/bar/crash.txt";
+		STDHelpers::Erase(filePath, depotPath);
+
+		TEST(filePath == "foo/bar/crash.txt", true);
+	}
+	{
+		std::string depotPath = "//depot/path/...";
+		std::string filePath = "//depot/path/foo/bar/crash.txt";
+		STDHelpers::Erase(filePath, depotPath);
+
+		TEST(filePath == "//depot/path/foo/bar/crash.txt", true);
+		TEST(filePath == "foo/bar/crash.txt", false);
+	}
+
 	TEST(Time::GetTimezoneMinutes("2022/03/15 09:56:15 -0400 EDT"), -240);
 	TEST(Time::GetTimezoneMinutes("2022/03/09 22:59:04 -0800 PST"), -480);
 	TEST(Time::GetTimezoneMinutes("2022/03/09 22:59:04 +0800 PST"), +480);


### PR DESCRIPTION
Let's mimic git-p4.py's behavior for this case