### PR TITLE
log: Add --noColor arg to disable coloured logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ These execution times are expected to scale as expected with larger depots (mill
   * Clone this repository or [get a release distribution](https://github.com/salesforce/p4-fusion/releases).
   * Get the Helix Core C++ API binaries from the [official Perforce website](https://www.perforce.com/downloads/helix-core-c/c-api).
     * Tested versions: 2021.1, 2021.2, 2022.1
-    * We recommend always picking the newest binaries that compiles with p4-fusion.
+    * We recommend always picking the newest API versions that compile with p4-fusion.
   * Extract the contents in `./vendor/helix-core-api/linux/` or `./vendor/helix-core-api/mac/` based on your OS.
 
 > For CentOS, you can try `yum install git make cmake gcc-c++ libarchive` to set up the compilation toolchain. Installing `libarchive` is only required to fix a bug that stops CMake from starting properly.

--- a/p4-fusion/common.h
+++ b/p4-fusion/common.h
@@ -13,17 +13,4 @@
 
 #include "p4/clientapi.h"
 
-#define PRINT(x) std::cout << "[ PRINT @ " << __func__ << ":" << __LINE__ << " ] " << x << std::endl
-
-#define ERR(x)                                                        \
-	std::cerr << "\033[91m"                                           \
-	          << "[ ERROR @ " << __func__ << ":" << __LINE__ << " ] " \
-	          << x << "\033[0m" << std::endl
-
-#define WARN(x) std::cerr << "\033[93m"                                             \
-	                      << "[ WARNING @ " << __func__ << ":" << __LINE__ << " ] " \
-	                      << x << "\033[0m" << std::endl
-
-#define SUCCESS(x) std::cerr << "\033[32m"                                             \
-	                         << "[ SUCCESS @ " << __func__ << ":" << __LINE__ << " ] " \
-	                         << x << "\033[0m" << std::endl
+#include "log.h"

--- a/p4-fusion/log.cc
+++ b/p4-fusion/log.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#include "log.h"
+
+#define COLOR_RED "\033[91m"
+#define COLOR_YELLOW "\033[93m"
+#define COLOR_GREEN "\033[32m"
+#define COLOR_NORMAL "\033[0m"
+
+const char* Log::ColorRed = COLOR_RED;
+const char* Log::ColorYellow = COLOR_YELLOW;
+const char* Log::ColorGreen = COLOR_GREEN;
+const char* Log::ColorNormal = COLOR_NORMAL;
+
+void Log::DisableColoredOutput()
+{
+	ColorRed = COLOR_NORMAL;
+	ColorYellow = COLOR_NORMAL;
+	ColorGreen = COLOR_NORMAL;
+	ColorNormal = COLOR_NORMAL;
+}

--- a/p4-fusion/log.h
+++ b/p4-fusion/log.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#pragma once
+
+class Log
+{
+public:
+	static const char* ColorRed;
+	static const char* ColorYellow;
+	static const char* ColorGreen;
+	static const char* ColorNormal;
+
+	static void DisableColoredOutput();
+};
+
+#define PRINT(x) std::cout << "[ PRINT @ " << __func__ << ":" << __LINE__ << " ] " << x << std::endl
+
+#define ERR(x)                                                        \
+	std::cerr << Log::ColorRed                                        \
+	          << "[ ERROR @ " << __func__ << ":" << __LINE__ << " ] " \
+	          << x << Log::ColorNormal << std::endl
+
+#define WARN(x) std::cerr << Log::ColorYellow                                       \
+	                      << "[ WARNING @ " << __func__ << ":" << __LINE__ << " ] " \
+	                      << x << Log::ColorNormal << std::endl
+
+#define SUCCESS(x) std::cerr << Log::ColorGreen                                        \
+	                         << "[ SUCCESS @ " << __func__ << ":" << __LINE__ << " ] " \
+	                         << x << Log::ColorNormal << std::endl

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -30,8 +30,6 @@ void SignalHandler(sig_atomic_t s);
 
 int Main(int argc, char** argv)
 {
-	PRINT("Running p4-fusion from: " << argv[0]);
-
 	Timer programTimer;
 
 	Arguments::GetSingleton()->RequiredParameter("--path", "P4 depot path to convert to a Git repo");
@@ -48,13 +46,20 @@ int Main(int argc, char** argv)
 	Arguments::GetSingleton()->OptionalParameter("--fsyncEnable", "false", "Enable fsync() while writing objects to disk to ensure they get written to permanent storage immediately instead of being cached. This is to mitigate data loss in events of hardware failure.");
 	Arguments::GetSingleton()->OptionalParameter("--includeBinaries", "false", "Do not discard binary files while downloading changelists.");
 	Arguments::GetSingleton()->OptionalParameter("--flushRate", "1000", "Rate at which profiling data is flushed on the disk.");
+	Arguments::GetSingleton()->OptionalParameter("--noColor", "false", "Disable colored output.");
+
+	PRINT("p4-fusion " P4_FUSION_VERSION);
 
 	Arguments::GetSingleton()->Initialize(argc, argv);
 	if (!Arguments::GetSingleton()->IsValid())
 	{
-		PRINT("p4-fusion " P4_FUSION_VERSION);
 		PRINT("Usage:" + Arguments::GetSingleton()->Help());
-		return 1;
+		return 0;
+	}
+
+	if (Arguments::GetSingleton()->GetNoColor() != "false")
+	{
+		Log::DisableColoredOutput();
 	}
 
 	const std::string depotPath = Arguments::GetSingleton()->GetDepotPath();
@@ -63,6 +68,8 @@ int Main(int argc, char** argv)
 	const bool includeBinaries = Arguments::GetSingleton()->GetIncludeBinaries() != "false";
 	const int maxChanges = std::atoi(Arguments::GetSingleton()->GetMaxChanges().c_str());
 	const int flushRate = std::atoi(Arguments::GetSingleton()->GetFlushRate().c_str());
+
+	PRINT("Running p4-fusion from: " << argv[0]);
 
 	if (!P4API::InitializeLibraries())
 	{

--- a/p4-fusion/utils/arguments.h
+++ b/p4-fusion/utils/arguments.h
@@ -51,4 +51,5 @@ public:
 	std::string GetIncludeBinaries() const { return GetParameter("--includeBinaries"); };
 	std::string GetMaxChanges() const { return GetParameter("--maxChanges"); };
 	std::string GetFlushRate() const { return GetParameter("--flushRate"); };
+	std::string GetNoColor() const { return GetParameter("--noColor"); };
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(p4-fusion-test
     ../p4-fusion/utils/std_helpers.cc
     ../p4-fusion/utils/time_helpers.cc
     ../p4-fusion/git_api.cc
+    ../p4-fusion/log.cc
 )
 
 target_include_directories(p4-fusion-test PRIVATE


### PR DESCRIPTION
Fixes #41 

I decided to implement it as a runtime switch instead of a compilation flag so that the same binary is configurable, and doesn't require a re-compilation to only disable colored outputs.