### PR TITLE
main: Add server connection check and bubble up errors as exit codes

### DIFF
--- a/p4-fusion/commands/test_result.cc
+++ b/p4-fusion/commands/test_result.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#include "test_result.h"
+
+void TestResult::OutputStat(StrDict* varList)
+{
+}
+
+void TestResult::OutputText(const char* data, int length)
+{
+}
+
+void TestResult::OutputBinary(const char* data, int length)
+{
+}

--- a/p4-fusion/commands/test_result.h
+++ b/p4-fusion/commands/test_result.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#pragma once
+
+#include "common.h"
+#include "result.h"
+
+class TestResult : public Result
+{
+public:
+	void OutputStat(StrDict* varList) override;
+	void OutputText(const char* data, int length) override;
+	void OutputBinary(const char* data, int length) override;
+};

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -82,6 +82,18 @@ int Main(int argc, char** argv)
 
 	P4API::P4PORT = Arguments::GetSingleton()->GetPort();
 	P4API::P4USER = Arguments::GetSingleton()->GetUsername();
+
+	const Error& serviceConnectionResult = P4API().TestConnection(5).GetError();
+	bool serverAvailable = serviceConnectionResult.IsError() == 0;
+	if (serverAvailable)
+	{
+		SUCCESS("Perforce server is available");
+	}
+	else
+	{
+		ERR("Error occurred while connecting to " << P4API::P4PORT);
+		return 1;
+	}
 	P4API::P4CLIENT = Arguments::GetSingleton()->GetClient();
 	P4API::ClientSpec = P4API().Client().GetClientSpec();
 
@@ -358,9 +370,11 @@ void SignalHandler(sig_atomic_t s)
 
 int main(int argc, char** argv)
 {
+	int exitCode = 0;
+
 	try
 	{
-		Main(argc, argv);
+		exitCode = Main(argc, argv);
 	}
 	catch (const std::exception& e)
 	{
@@ -368,5 +382,5 @@ int main(int argc, char** argv)
 		return 1;
 	}
 
-	return 0;
+	return exitCode;
 }

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -227,6 +227,11 @@ ClientResult P4API::Client()
 	return Run<ClientResult>("client", { "-o" });
 }
 
+TestResult P4API::TestConnection(const int retries)
+{
+	return RunEx<TestResult>("changes", { "-m", "1", "//..." }, retries);
+}
+
 ChangesResult P4API::ShortChanges(const std::string& path)
 {
 	return Run<ChangesResult>("changes", {


### PR DESCRIPTION
The number of retries when testing the connection before actually carrying out the usual business is hard-coded to 5.

It doesn't seem to me that users would require flexibility in a simple connection test.