### PR TITLE
feat(p4_api): support older perforce servers

### DIFF
--- a/p4-fusion/commands/changes_result.cc
+++ b/p4-fusion/commands/changes_result.cc
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+#include <algorithm>
 #include "changes_result.h"
 
 void ChangesResult::OutputStat(StrDict* varList)
@@ -13,4 +14,9 @@ void ChangesResult::OutputStat(StrDict* varList)
 	    varList->GetVar("desc")->Text(),
 	    varList->GetVar("user")->Text(),
 	    varList->GetVar("time")->Atoi64());
+}
+
+void ChangesResult::reverse()
+{
+	std::reverse(m_Changes.begin(), m_Changes.end());
 }

--- a/p4-fusion/commands/changes_result.h
+++ b/p4-fusion/commands/changes_result.h
@@ -7,9 +7,7 @@
 #pragma once
 
 #include <vector>
-
 #include "common.h"
-
 #include "change_list.h"
 #include "result.h"
 
@@ -20,6 +18,7 @@ private:
 
 public:
 	std::vector<ChangeList>& GetChanges() { return m_Changes; }
+	void reverse();
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -177,11 +177,12 @@ TestResult P4API::TestConnection(const int retries)
 
 ChangesResult P4API::ShortChanges(const std::string& path)
 {
-	return Run<ChangesResult>("changes", {
-	                                         "-r", // Get CLs from earliest to latest
-	                                         "-s", "submitted", // Only include submitted CLs
-	                                         path // Depot path to get CLs from
-	                                     });
+	ChangesResult changes = Run<ChangesResult>("changes", {
+	                                                          "-s", "submitted", // Only include submitted CLs
+	                                                          path // Depot path to get CLs from
+	                                                      });
+	changes.reverse();
+	return changes;
 }
 
 ChangesResult P4API::Changes(const std::string& path)
@@ -199,7 +200,6 @@ ChangesResult P4API::Changes(const std::string& path, const std::string& from, i
 	std::vector<std::string> args = {
 		"-l", // Get full descriptions instead of sending cut-short ones
 		"-s", "submitted", // Only include submitted CLs
-		"-r" // Send CLs in chronological order
 	};
 
 	// This needs to be declared outside the if scope below to
@@ -226,7 +226,7 @@ ChangesResult P4API::Changes(const std::string& path, const std::string& from, i
 	args.push_back(path + pathAddition);
 
 	ChangesResult result = Run<ChangesResult>("changes", args);
-
+	result.reverse();
 	return result;
 }
 
@@ -251,12 +251,13 @@ ChangesResult P4API::LatestChange(const std::string& path)
 
 ChangesResult P4API::OldestChange(const std::string& path)
 {
-	return Run<ChangesResult>("changes", {
-	                                         "-s", "submitted", // Only include submitted CLs,
-	                                         "-r", // List from earliest to latest
-	                                         "-m", "1", // Get top-most change
-	                                         path // Depot path to get CLs from
-	                                     });
+	ChangesResult changes = Run<ChangesResult>("changes", {
+	                                                          "-s", "submitted", // Only include submitted CLs,
+	                                                          "-m", "1", // Get top-most change
+	                                                          path // Depot path to get CLs from
+	                                                      });
+	changes.reverse();
+	return changes;
 }
 
 DescribeResult P4API::Describe(const std::string& cl)


### PR DESCRIPTION
This change allows use of this software with older perforce servers and clients which don't support "-r" option.
See https://github.com/salesforce/p4-fusion/issues/52 for more.