### PR TITLE
Fix memory leaks

### DIFF
--- a/p4-fusion/commands/file_map.cc
+++ b/p4-fusion/commands/file_map.cc
@@ -27,7 +27,8 @@ bool FileMap::IsInLeft(const std::string fileRevision) const
 	argMap.Insert(StrBuf(fileRevision.c_str()), MapType::MapInclude);
 
 	// MapAPI is poorly written and doesn't declare things as const when it should.
-	return MapApi::Join(const_cast<MapApi*>(&m_map), &argMap) != nullptr;
+	std::unique_ptr<MapApi> joinResult(MapApi::Join(const_cast<MapApi*>(&m_map), &argMap));
+	return joinResult != nullptr;
 }
 
 bool FileMap::IsInRight(const std::string fileRevision) const

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -188,6 +188,7 @@ void GitAPI::CreateIndex()
 		git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL);
 		git_revwalk_push_head(walk);
 		git_revwalk_next(&m_FirstCommitOid, walk);
+		git_revwalk_free(walk);
 
 		WARN("Loaded index was refreshed to match the tree of the current HEAD commit");
 	}


### PR DESCRIPTION
Even though these leaks are pretty small, when using "branching mode", the one in `IsInLeft` accumulates quickly over time. For example, running the tool over the weekend resulted in 80+ GBs of allocated memory in my case.

On e.g. macOS, the presence of memory leaks can be checked easily: `export MallocStackLogging=1;leaks --atExit -- p4-fusion [parameters];unset MallocStackLogging`