### PR TITLE
Fix crash due to incorrect condition variable usage

### DIFF
--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -20,10 +20,10 @@ ChangeList::ChangeList(const std::string& clNumber, const std::string& clDescrip
     , description(clDescription)
     , timestamp(clTimestamp)
     , changedFileGroups(ChangedFileGroups::Empty())
-	, stateCV(new std::condition_variable())
-	, stateMutex(new std::mutex())
-	, filesDownloaded(-1)
-	, state(Initialized)
+    , stateCV(new std::condition_variable())
+    , stateMutex(new std::mutex())
+    , filesDownloaded(-1)
+    , state(Initialized)
 {
 }
 

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -20,8 +20,8 @@ ChangeList::ChangeList(const std::string& clNumber, const std::string& clDescrip
     , description(clDescription)
     , timestamp(clTimestamp)
     , changedFileGroups(ChangedFileGroups::Empty())
-	, stateCV(new std::condition_variable ())
-	, stateMutex(new std::mutex ())
+	, stateCV(new std::condition_variable())
+	, stateMutex(new std::mutex())
 	, filesDownloaded(-1)
 	, state(Initialized)
 {
@@ -52,9 +52,9 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 			    cl.changedFileGroups = branchSet.ParseAffectedFiles(describe.GetFileData());
 		    }
 
-			std::unique_lock<std::mutex> lock(*(cl.stateMutex));
-			cl.state = Described;
-			cl.stateCV->notify_all();
+		    std::unique_lock<std::mutex> lock(*cl.stateMutex);
+		    cl.state = Described;
+		    cl.stateCV->notify_all();
 	    });
 }
 
@@ -126,13 +126,13 @@ void ChangeList::Flush(std::shared_ptr<std::vector<std::string>> printBatchFiles
 			    }
 		    }
 
-			std::lock_guard<std::mutex> lock(*stateMutex);
-			filesDownloaded += printBatchFiles->size();
-			if (filesDownloaded == changedFileGroups->totalFileCount)
-			{
-				state = Downloaded;
-				stateCV->notify_all();
-			}
+		    std::lock_guard<std::mutex> lock(*stateMutex);
+		    filesDownloaded += printBatchFiles->size();
+		    if (filesDownloaded == changedFileGroups->totalFileCount)
+		    {
+			    state = Downloaded;
+			    stateCV->notify_all();
+		    }
 	    });
 }
 

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -20,6 +20,10 @@ ChangeList::ChangeList(const std::string& clNumber, const std::string& clDescrip
     , description(clDescription)
     , timestamp(clTimestamp)
     , changedFileGroups(ChangedFileGroups::Empty())
+	, stateCV(new std::condition_variable ())
+	, stateMutex(new std::mutex ())
+	, filesDownloaded(-1)
+	, state(Initialized)
 {
 }
 
@@ -48,11 +52,9 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 			    cl.changedFileGroups = branchSet.ParseAffectedFiles(describe.GetFileData());
 		    }
 
-		    {
-			    std::unique_lock<std::mutex> lock((*(cl.canDownloadMutex)));
-			    *cl.canDownload = true;
-		    }
-		    cl.canDownloadCV->notify_all();
+			std::unique_lock<std::mutex> lock(*(cl.stateMutex));
+			cl.state = Described;
+			cl.stateCV->notify_all();
 	    });
 }
 
@@ -64,12 +66,12 @@ void ChangeList::StartDownload(const int& printBatch)
 	    {
 		    // Wait for describe to finish, if it is still running
 		    {
-			    std::unique_lock<std::mutex> lock(*(cl.canDownloadMutex));
-			    cl.canDownloadCV->wait(lock, [&cl]()
-			        { return *(cl.canDownload) == true; });
+			    std::unique_lock<std::mutex> lock(*cl.stateMutex);
+			    cl.stateCV->wait(lock, [&cl]()
+			        { return cl.state == Described; });
 		    }
 
-		    *cl.filesDownloaded = 0;
+		    cl.filesDownloaded = 0;
 
 		    std::shared_ptr<std::vector<std::string>> printBatchFiles = std::make_shared<std::vector<std::string>>();
 		    std::shared_ptr<std::vector<FileData*>> printBatchFileData = std::make_shared<std::vector<FileData*>>();
@@ -122,20 +124,23 @@ void ChangeList::Flush(std::shared_ptr<std::vector<std::string>> printBatchFiles
 			    {
 				    printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
 			    }
-
-			    (*filesDownloaded) += printBatchFiles->size();
 		    }
 
-		    // Ensure the notify_all is called.
-		    commitCV->notify_all();
+			std::lock_guard<std::mutex> lock(*stateMutex);
+			filesDownloaded += printBatchFiles->size();
+			if (filesDownloaded == changedFileGroups->totalFileCount)
+			{
+				state = Downloaded;
+				stateCV->notify_all();
+			}
 	    });
 }
 
 void ChangeList::WaitForDownload()
 {
-	std::unique_lock<std::mutex> lock(*commitMutex);
-	commitCV->wait(lock, [this]()
-	    { return *(filesDownloaded) == (int)changedFileGroups->totalFileCount; });
+	std::unique_lock<std::mutex> lock(*stateMutex);
+	stateCV->wait(lock, [this]()
+	    { return state == Downloaded; });
 }
 
 void ChangeList::Clear()
@@ -145,10 +150,8 @@ void ChangeList::Clear()
 	description.clear();
 	changedFileGroups->Clear();
 
-	filesDownloaded.reset();
-	canDownload.reset();
-	canDownloadMutex.reset();
-	canDownloadCV.reset();
-	commitMutex.reset();
-	commitCV.reset();
+	stateCV.release();
+	stateMutex.release();
+	filesDownloaded = -1;
+	state = Freed;
 }

--- a/p4-fusion/commands/change_list.h
+++ b/p4-fusion/commands/change_list.h
@@ -16,7 +16,8 @@
 
 struct ChangeList
 {
-	enum State {
+	enum State
+	{
 		Initialized,
 		Described,
 		Downloaded,

--- a/p4-fusion/commands/change_list.h
+++ b/p4-fusion/commands/change_list.h
@@ -16,22 +16,27 @@
 
 struct ChangeList
 {
+	enum State {
+		Initialized,
+		Described,
+		Downloaded,
+		Freed
+	};
+
 	std::string number;
 	std::string user;
 	std::string description;
 	int64_t timestamp = 0;
 	std::unique_ptr<ChangedFileGroups> changedFileGroups = ChangedFileGroups::Empty();
 
-	std::shared_ptr<std::atomic<int>> filesDownloaded = std::make_shared<std::atomic<int>>(-1);
-	std::shared_ptr<std::atomic<bool>> canDownload = std::make_shared<std::atomic<bool>>(false);
-	std::shared_ptr<std::mutex> canDownloadMutex = std::make_shared<std::mutex>();
-	std::shared_ptr<std::condition_variable> canDownloadCV = std::make_shared<std::condition_variable>();
-	std::shared_ptr<std::mutex> commitMutex = std::make_shared<std::mutex>();
-	std::shared_ptr<std::condition_variable> commitCV = std::make_shared<std::condition_variable>();
+	std::unique_ptr<std::condition_variable> stateCV;
+	std::unique_ptr<std::mutex> stateMutex;
+	int filesDownloaded;
+	State state;
 
 	ChangeList(const std::string& number, const std::string& description, const std::string& user, const int64_t& timestamp);
 
-	ChangeList(const ChangeList& other) = default;
+	ChangeList(const ChangeList& other) = delete;
 	ChangeList& operator=(const ChangeList&) = delete;
 	ChangeList(ChangeList&&) = default;
 	ChangeList& operator=(ChangeList&&) = default;


### PR DESCRIPTION
- There was a race condition on the condition variable, when `ChangeList::Flush` called `notify_all`. After the waiter (in this case, the main thread) is woken up, `notify_all` might not have returned just yet. If the main thread proceeded and called `Clear` on the `ChangeList` object in the meantime, the condition variable is deleted when `notify_all` is still executing, causing a crash. This occurs frequently on my machine when running the tool in "branching mode", and there are changelists happening on lots of "uninteresting" branches (in other words: changelists with 0 files to be committed).
- As part of the bugfix, synchronization in the `ChangeList` class is reworked: instead of multiple atomic variables, mutexes, and condition variables, a single condition variable and mutex is used, with a state machine.