### PR TITLE
Fix build on macOS with newer P4 SDK versions by linking with the p4s…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
     - name: Install Helix Core C++ API
       run: |
         mkdir -p vendor/helix-core-api/linux
-        wget https://www.perforce.com/downloads/perforce/r21.1/bin.linux26x86_64/p4api.tgz
-        tar -C vendor/helix-core-api/linux -xzf p4api.tgz --strip 1
+        wget https://www.perforce.com/downloads/perforce/r24.1/bin.linux26x86_64/p4api-glibc2.12-openssl1.1.1.tgz
+        tar -C vendor/helix-core-api/linux -xzf p4api-glibc2.12-openssl1.1.1.tgz --strip 1
 
     - name: Configure CMake cache
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,13 @@ jobs:
           ${{ runner.OS }}-p4-fusion-vendor-cache-
 
     # Adopted from: https://github.com/sourcegraph/sourcegraph/blob/main/cmd/gitserver/p4-fusion-install-alpine.sh#L82
-    - name: Install OpenSSL 1.0.2t
+    - name: Install OpenSSL 1.1.1w
       run: |
         pushd vendor
 
         mkdir -p openssl-src
-        wget https://www.openssl.org/source/openssl-1.0.2t.tar.gz
-        tar -C openssl-src -xzf openssl-1.0.2t.tar.gz --strip 1
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -C openssl-src -xzf openssl-1.1.1w.tar.gz --strip 1
         pushd openssl-src
         ./config
         make build_libs

--- a/p4-fusion/CMakeLists.txt
+++ b/p4-fusion/CMakeLists.txt
@@ -45,10 +45,9 @@ target_link_libraries(p4-fusion PUBLIC
     client
     rpc
     supp
+    p4script_cstub
     ${OPENSSL_SSL_LIBRARIES}
     ${OPENSSL_CRYPTO_LIBRARIES}
-    p4script
-    p4script_c
     git2
     minitrace
 )


### PR DESCRIPTION
…cript_cstub library, for #78

- The p4client library seems to have unconditional references to the P4Script machinery, even if that feature is not used by the application (in this case, p4-fusion). This causes linking errors (undefined references to sqlite, and curl functions)
- The p4script_cstub library seems to be an official solution for this situation, as it contains stubs (dummy, empty implementations) of all relevant functions