### PR TITLE
Fix leak in change_list.cc

### DIFF
--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -150,8 +150,8 @@ void ChangeList::Clear()
 	description.clear();
 	changedFileGroups->Clear();
 
-	stateCV.release();
-	stateMutex.release();
+	stateCV.reset();
+	stateMutex.reset();
 	filesDownloaded = -1;
 	state = Freed;
 }


### PR DESCRIPTION
An unfortunate regression I introduced [here](https://github.com/salesforce/p4-fusion/pull/77).

`release` plainly releases ownership without deleting the object, `reset` is the correct method to call in this case.

Sorry about the mistake, in the future I'll make sure to perform a leak check on my changes before opening a PR!