### PR TITLE
Fix for case where some server configs result in empty repos

### DIFF
--- a/p4-fusion/commands/describe_result.cc
+++ b/p4-fusion/commands/describe_result.cc
@@ -8,6 +8,11 @@
 
 void DescribeResult::OutputStat(StrDict* varList)
 {
+	int result = 0;
+	do
+	{
+		result = OutputStatPartial(varList);
+	} while (result == 1);
 }
 
 int DescribeResult::OutputStatPartial(StrDict* varList)


### PR DESCRIPTION
I had to use p4-fusion on two different perforce servers and one of them only ever had full results for DescribeResult so this flushes to make sure that all changelists are described and stuff

I'm not sure if it was the file type (+IS10) or if it was an actual server issue but this fixed it and does not affect servers where it's not an issue afaik