### PR TITLE
Fix symlink handling after Perforce to Git conversion

### DIFF
--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -91,6 +91,11 @@ bool FileData::IsExecutable() const
 	return STDHelpers::Contains(m_data->type, "+x");
 }
 
+bool FileData::IsSymlink() const
+{
+	return STDHelpers::Contains(m_data->type, "+l") || STDHelpers::Contains(m_data->type, "symlink");
+}
+
 FileAction extrapolateFileAction(std::string& action);
 
 void FileDataStore::SetAction(std::string fileAction)

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -97,6 +97,8 @@ public:
 
 	bool IsBinary() const;
 	bool IsExecutable() const;
+	bool IsSymlink() const;
+
 
 	void Clear() { m_data->Clear(); };
 };

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -221,20 +221,36 @@ void GitAPI::CreateIndex()
 	}
 }
 
-void GitAPI::AddFileToIndex(const std::string& relativePath, const std::vector<char>& contents, const bool plusx)
+void GitAPI::AddFileToIndex(const std::string& relativePath, const std::vector<char>& contents, const bool plusx, const bool isSymlink)
 {
 	MTR_SCOPE("Git", __func__);
 
 	git_index_entry entry = {};
-	entry.mode = GIT_FILEMODE_BLOB;
-	if (plusx)
+	
+	if (isSymlink)
 	{
-		entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE; // 0100755
+		entry.mode = GIT_FILEMODE_LINK; // 0120000
+		
+		std::vector<char> cleanedContents = contents;
+		while (!cleanedContents.empty() && (cleanedContents.back() == '\n' || cleanedContents.back() == '\r'))
+		{
+			cleanedContents.pop_back();
+		}
+		
+		entry.path = relativePath.c_str();
+		GIT2(git_index_add_from_buffer(m_Index, &entry, cleanedContents.data(), cleanedContents.size()));
 	}
-
-	entry.path = relativePath.c_str();
-
-	GIT2(git_index_add_from_buffer(m_Index, &entry, contents.data(), contents.size()));
+	else
+	{
+		entry.mode = GIT_FILEMODE_BLOB;
+		if (plusx)
+		{
+			entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE; // 0100755
+		}
+		
+		entry.path = relativePath.c_str();
+		GIT2(git_index_add_from_buffer(m_Index, &entry, contents.data(), contents.size()));
+	}
 }
 
 void GitAPI::RemoveFileFromIndex(const std::string& relativePath)

--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -38,7 +38,7 @@ public:
 
 	void CreateIndex();
 	void SetActiveBranch(const std::string& branchName);
-	void AddFileToIndex(const std::string& relativePath, const std::vector<char>& contents, const bool plusx);
+	void AddFileToIndex(const std::string& relativePath, const std::vector<char>& contents, const bool plusx, const bool isSymlink = false);
 	void RemoveFileFromIndex(const std::string& relativePath);
 
 	std::string Commit(

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -396,7 +396,7 @@ int Main(int argc, char** argv)
 				}
 				else
 				{
-					git.AddFileToIndex(file.GetRelativePath(), file.GetContents(), file.IsExecutable());
+					git.AddFileToIndex(file.GetRelativePath(), file.GetContents(), file.IsExecutable(), file.IsSymlink());
 				}
 
 				// No use for keeping the contents in memory once it has been added


### PR DESCRIPTION
Resolved an issue where symbolic links were broken in the Git repository after converting from Perforce (P4). Updated the conversion logic to correctly handle symlinks, ensuring they are preserved and functional in the resulting Git repository.