### PR TITLE
Handle P4 special characters

### DIFF
--- a/p4-fusion/branch_set.cc
+++ b/p4-fusion/branch_set.cc
@@ -10,16 +10,6 @@
 static const std::string EMPTY_STRING = "";
 static const std::array<std::string, 2> INVALID_BRANCH_PATH { EMPTY_STRING, EMPTY_STRING };
 
-std::vector<std::string> BranchedFileGroup::GetRelativeFileNames()
-{
-	std::vector<std::string> ret;
-	for (auto& fileData : files)
-	{
-		ret.push_back(fileData.GetRelativePath());
-	}
-	return ret;
-}
-
 ChangedFileGroups::ChangedFileGroups()
     : totalFileCount(0)
 {
@@ -295,7 +285,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 
 			// It's a valid destination to a branch.
 			// Make sure the relative path is set.
-			fileData.SetRelativePath(branchPath[1]);
+			fileData.SetRelativeDepotPath(branchPath[1]);
 
 			bool needsHandling = true;
 			if (fileData.IsIntegrated())
@@ -326,7 +316,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 		{
 			// It's a non-branching setup.
 			// Make sure the relative path is set.
-			fileData.SetRelativePath(relativeDepotPath);
+			fileData.SetRelativeDepotPath(relativeDepotPath);
 			branchMap.addTarget(EMPTY_STRING, fileData);
 		}
 	}

--- a/p4-fusion/branch_set.h
+++ b/p4-fusion/branch_set.h
@@ -27,9 +27,6 @@ struct BranchedFileGroup
 	std::string targetBranch;
 	bool hasSource;
 	std::vector<FileData> files;
-
-	// Get all the relative file names from each of the file data.
-	std::vector<std::string> GetRelativeFileNames();
 };
 
 struct ChangedFileGroups

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -76,7 +76,7 @@ void FileData::SetPendingDownload()
 	}
 }
 
-void FileData::SetRelativePath(std::string& relativePath)
+void FileData::SetRelativeDepotPath(const std::string& relativePath)
 {
 	m_data->relativePath = relativePath;
 }

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -76,7 +76,7 @@ public:
 	FileData& operator=(FileData& other);
 
 	void SetFromDepotFile(const std::string& fromDepotFile, const std::string& fromRevision);
-	void SetRelativePath(std::string& relativePath);
+	void SetRelativeDepotPath(const std::string& relativePath);
 	void SetFakeIntegrationDeleteAction() { m_data->SetAction(FAKE_INTEGRATION_DELETE_ACTION_NAME); };
 
 	// moves the argument's data into this file data structure.
@@ -88,7 +88,7 @@ public:
 	const std::string& GetDepotFile() const { return m_data->depotFile; };
 	const std::string& GetRevision() const { return m_data->revision; };
 	const FileAction GetAction() const { return m_data->actionCategory; };
-	const std::string& GetRelativePath() const { return m_data->relativePath; };
+	const std::string& GetRelativeDepotPath() const { return m_data->relativePath; };
 	const std::vector<char>& GetContents() const { return m_data->contents; };
 	bool IsDeleted() const { return m_data->isDeleted; };
 	bool IsIntegrated() const { return m_data->isIntegrated; };

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -15,6 +15,7 @@
 #include "utils/std_helpers.h"
 #include "utils/timer.h"
 #include "utils/arguments.h"
+#include "utils/p4_helpers.h"
 
 #include "thread_pool.h"
 #include "p4_api.h"
@@ -390,13 +391,14 @@ int Main(int argc, char** argv)
 
 			for (auto& file : branchGroup.files)
 			{
+				const std::string unescapedPath = P4Unescape(file.GetRelativeDepotPath());
 				if (file.IsDeleted())
 				{
-					git.RemoveFileFromIndex(file.GetRelativePath());
+					git.RemoveFileFromIndex(unescapedPath);
 				}
 				else
 				{
-					git.AddFileToIndex(file.GetRelativePath(), file.GetContents(), file.IsExecutable());
+					git.AddFileToIndex(unescapedPath, file.GetContents(), file.IsExecutable());
 				}
 
 				// No use for keeping the contents in memory once it has been added

--- a/p4-fusion/utils/p4_helpers.cc
+++ b/p4-fusion/utils/p4_helpers.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#include "p4_helpers.h"
+
+#include "std_helpers.h"
+
+std::string P4Unescape(std::string p4path)
+{
+	STDHelpers::ReplaceAll(p4path, "%40", "@");
+	STDHelpers::ReplaceAll(p4path, "%23", "#");
+	STDHelpers::ReplaceAll(p4path, "%2A", "*");
+	// Replace %25 last to avoid interfering with other escape sequences
+	STDHelpers::ReplaceAll(p4path, "%25", "%");
+	return p4path;
+}

--- a/p4-fusion/utils/p4_helpers.h
+++ b/p4-fusion/utils/p4_helpers.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#pragma once
+
+#include <string>
+
+std::string P4Unescape(std::string p4path);

--- a/p4-fusion/utils/std_helpers.cc
+++ b/p4-fusion/utils/std_helpers.cc
@@ -67,6 +67,25 @@ void STDHelpers::StripSurrounding(std::string& source, const char c)
 	}
 }
 
+std::string STDHelpers::ToLower(const std::string& source)
+{
+	std::string result = source;
+	std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+	return result;
+}
+
+void STDHelpers::ReplaceAll(std::string& str, const std::string& find, const std::string& replace)
+{
+	std::string::size_type pos;
+	std::string::size_type startPos = 0;
+
+	while ((pos = str.find(find, startPos)) != std::string::npos)
+	{
+		str.replace(pos, find.length(), replace);
+		startPos = pos + replace.length();
+	}
+}
+
 std::array<std::string, 2> STDHelpers::SplitAt(const std::string& source, const char c, const size_t startAt)
 {
 	size_t pos = source.find(c, startAt);

--- a/p4-fusion/utils/std_helpers.cc
+++ b/p4-fusion/utils/std_helpers.cc
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include "std_helpers.h"
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/p4-fusion/utils/std_helpers.h
+++ b/p4-fusion/utils/std_helpers.h
@@ -18,6 +18,8 @@ public:
 	static bool Contains(const std::string& str, const std::string& subStr);
 	static void Erase(std::string& source, const std::string& subStr);
 	static void StripSurrounding(std::string& source, const char c);
+	static std::string ToLower(const std::string& source);
+	static void ReplaceAll(std::string& str, const std::string& find, const std::string& replace);
 
 	// Split the source into two strings at the first character 'c' after position 'startAt'.  The 'c' character is
 	// not included in the returned strings.  Text before the 'startAt' will not be included.


### PR DESCRIPTION
P4V restores the original filenames when syncing a file, but in the command line output of p4 commands the escapes are not restored, therefore the escape sequences "escaped" through p4-fusion into the Git repo filenames. This change resolves this bug.