### PR TITLE
Add input validation to prevent crashes on malformed metadata

### DIFF
--- a/p4-fusion/commands/print_result.cc
+++ b/p4-fusion/commands/print_result.cc
@@ -13,6 +13,11 @@ void PrintResult::OutputStat(StrDict* varList)
 
 void PrintResult::OutputText(const char* data, int length)
 {
+	if (m_Data.empty())
+	{
+		WARN("Received file content before OutputStat header. Skipping.");
+		return;
+	}
 	std::vector<char>& fileContent = m_Data.back().contents;
 	fileContent.insert(fileContent.end(), data, data + length);
 }

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -64,9 +64,17 @@ bool GitAPI::IsRepositoryClonedFrom(const std::string& depotPath)
 	GIT2(git_commit_lookup(&headCommit, m_Repo, &oid));
 
 	std::string message = git_commit_message(headCommit);
-	size_t depotPathStart = message.find("depot-paths = \"") + 15;
-	size_t depotPathEnd = message.find("\": change") - 1;
-	std::string repoDepotPath = message.substr(depotPathStart, depotPathEnd - depotPathStart + 1) + "...";
+
+	size_t startMarker = message.find("depot-paths = \"");
+	size_t endMarker = message.find("\": change");
+	if (startMarker == std::string::npos || endMarker == std::string::npos || endMarker <= startMarker + 15)
+	{
+		WARN("HEAD commit does not contain p4-fusion metadata. Cannot verify depot path.");
+		git_commit_free(headCommit);
+		return false;
+	}
+	size_t depotPathStart = startMarker + 15;
+	std::string repoDepotPath = message.substr(depotPathStart, endMarker - depotPathStart) + "...";
 
 	git_commit_free(headCommit);
 
@@ -161,11 +169,22 @@ std::string GitAPI::DetectLatestCL()
 	GIT2(git_commit_lookup(&headCommit, m_Repo, &oid));
 
 	std::string message = git_commit_message(headCommit);
-	// Look for the specific change message generated from the Commit method.
-	// Note that extra branching information can be added after it.
-	// ": change = " is 11 characters long.
-	size_t clStart = message.rfind(": change = ") + 11;
+
+	size_t marker = message.rfind(": change = ");
+	if (marker == std::string::npos)
+	{
+		ERR("HEAD commit does not contain p4-fusion changelist metadata.");
+		git_commit_free(headCommit);
+		return "";
+	}
+	size_t clStart = marker + 11;
 	size_t clEnd = message.find(']', clStart);
+	if (clEnd == std::string::npos)
+	{
+		ERR("Malformed p4-fusion metadata in HEAD commit.");
+		git_commit_free(headCommit);
+		return "";
+	}
 	std::string cl(message, clStart, clEnd - clStart);
 
 	git_commit_free(headCommit);

--- a/p4-fusion/utils/time_helpers.cc
+++ b/p4-fusion/utils/time_helpers.cc
@@ -6,16 +6,30 @@
  */
 #include "time_helpers.h"
 
+#include <cctype>
+#include <iostream>
+
+#include "log.h"
+
 int Time::GetTimezoneMinutes(const std::string& timezoneStr)
 {
-	// string -> ... serverDate 2021/09/06 04:49:28 -0700 PDT
-	//                          ^                   ^
-	// index  ->                0                  20
-	std::string timezone = timezoneStr.substr(20, 5);
+	// Expected format: "YYYY/MM/DD HH:MM:SS [+-]HHMM TZ"
+	// The timezone sign is at index 20, digits at 21-24.
+	if (timezoneStr.size() < 25)
+	{
+		WARN("Could not parse timezone from serverDate: '" << timezoneStr << "'. Defaulting to UTC.");
+		return 0;
+	}
 
-	int hours = std::stoi(timezone.substr(1, 2));
-	int minutes = std::stoi(timezone.substr(3, 2));
-	int sign = timezone[0] == '-' ? -1 : +1;
+	char c = timezoneStr[20];
+	if ((c != '+' && c != '-') || !std::isdigit(static_cast<unsigned char>(timezoneStr[21])) || !std::isdigit(static_cast<unsigned char>(timezoneStr[22])) || !std::isdigit(static_cast<unsigned char>(timezoneStr[23])) || !std::isdigit(static_cast<unsigned char>(timezoneStr[24])))
+	{
+		WARN("Could not parse timezone from serverDate: '" << timezoneStr << "'. Defaulting to UTC.");
+		return 0;
+	}
 
+	int sign = (c == '-') ? -1 : 1;
+	int hours = (timezoneStr[21] - '0') * 10 + (timezoneStr[22] - '0');
+	int minutes = (timezoneStr[23] - '0') * 10 + (timezoneStr[24] - '0');
 	return sign * (hours * 60 + minutes);
 }


### PR DESCRIPTION
Harden string parsing in GitAPI::IsRepositoryClonedFrom, GitAPI::DetectLatestCL, Time::GetTimezoneMinutes, and PrintResult::OutputText to gracefully handle missing or malformed input instead of crashing via integer underflow, uncaught exceptions, or undefined behavior on empty containers.