### PR TITLE
p4-fusion with option --client doesn't work optimally; IsInLeft() always returning true fix

### DIFF
--- a/p4-fusion/commands/file_map.cc
+++ b/p4-fusion/commands/file_map.cc
@@ -22,13 +22,12 @@ FileMap::FileMap(const FileMap& src)
 
 bool FileMap::IsInLeft(const std::string fileRevision) const
 {
-	MapApi argMap;
-	argMap.SetCaseSensitivity(m_sensitivity);
-	argMap.Insert(StrBuf(fileRevision.c_str()), MapType::MapInclude);
+	StrBuf from(fileRevision.c_str());
+	StrBuf to;
 
 	// MapAPI is poorly written and doesn't declare things as const when it should.
-	std::unique_ptr<MapApi> joinResult(MapApi::Join(const_cast<MapApi*>(&m_map), &argMap));
-	return joinResult != nullptr;
+	MapApi* ref = const_cast<MapApi*>(&m_map);
+	return ref->Translate(from, to, MapDir::MapLeftRight);
 }
 
 bool FileMap::IsInRight(const std::string fileRevision) const


### PR DESCRIPTION
This PR aims to fix the bug where client mapping is set to occlude files and folders that we don't want to be migrated.

Long story short, our intention was to create specific client view, and to create git repo to be the same as the client view - as per the p4-fusion should work. It turns out that even in that case, we found in our own logs presence of downlaoded files that are occluded by p4 client views, leading us investigate further, and getting to IsInLeft call.

 MapApi::Join returns a valid (merely empty) MapApi when the two maps do not intersect, so the null test never fires. Original `joinResult != nullptr` test was true for every path and the client View filtered nothing. Translate() fails when the path is unmapped or excluded, which is the semantics we need.
	
In our own very huge repo, we're testing with the fix I proposed, and turns out that processing is much faster, bandwidth much lower (as we expected due to perfectly set p4 client view). 